### PR TITLE
fix tag in config from 1.4.0 to v1.4.0

### DIFF
--- a/org/ystia/README.rst
+++ b/org/ystia/README.rst
@@ -124,7 +124,7 @@ For the second method:
 
   - Repository URL: https://github.com/alien4cloud/csar-public-library.git
   - Credentials: *none*
-  - Tag: **1.4.0**
+  - Tag: **v1.4.0**
   - Archive to import: **org/ystia**
 
 - and then execute the import operation.


### PR DESCRIPTION
The tag 1.4.0 does not exists in this repository, it should be v1.4.0