### PR TITLE
Scripts for elasticsearch on rpm based os

### DIFF
--- a/org/alien4cloud/elasticsearch/centos/README.md
+++ b/org/alien4cloud/elasticsearch/centos/README.md
@@ -1,0 +1,12 @@
+The TOSCA types in this service template are used to build an ALIEN topology with Higth Availability capabilities.
+
+The HA, when managed by this plugin is a primary/backup mode with an election mecanism based on Consul: only one Alien node can be elected as a leader at a given time.
+
+A typically HA topology could be:
+
+- a Consul cluster of at least 3 consul agents in server mode.
+- an ElasticSearch cluster of at least 2 nodes in replicated mode.
+- an ALIEN cluster of at least 2 nodes with HA mode enabled.
+- a reverse proxy: Nginx. Near this reverse proxy, we can use Consul-Template to automatically configure Nginx regarding changes in Consul.
+- since ALIEN use local file system to store data (archives, plugins ...), we need a distributed (and eventually replicated or at least backuped) file system. We use a Samba server in order to make our ALIEN instances sharing the same file system.
+

--- a/org/alien4cloud/elasticsearch/centos/config/elasticsearch/elasticsearch.yml
+++ b/org/alien4cloud/elasticsearch/centos/config/elasticsearch/elasticsearch.yml
@@ -1,0 +1,386 @@
+##################### Elasticsearch Configuration Example #####################
+
+# This file contains an overview of various configuration settings,
+# targeted at operations staff. Application developers should
+# consult the guide at <http://elasticsearch.org/guide>.
+#
+# The installation procedure is covered at
+# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/setup.html>.
+#
+# Elasticsearch comes with reasonable defaults for most settings,
+# so you can try it out without bothering with configuration.
+#
+# Most of the time, these defaults are just fine for running a production
+# cluster. If you're fine-tuning your cluster, or wondering about the
+# effect of certain configuration option, please _do ask_ on the
+# mailing list or IRC channel [http://elasticsearch.org/community].
+
+# Any element in the configuration can be replaced with environment variables
+# by placing them in ${...} notation. For example:
+#
+#node.rack: ${RACK_ENV_VAR}
+
+# For information on supported formats and syntax for the config file, see
+# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/setup-configuration.html>
+
+
+################################### Cluster ###################################
+
+# Cluster name identifies your cluster for auto-discovery. If you're running
+# multiple clusters on the same network, make sure you're using unique names.
+#
+cluster.name: alien4cloud
+
+
+#################################### Node #####################################
+
+# Node names are generated dynamically on startup, so you're relieved
+# from configuring them manually. You can tie this node to a specific name:
+#
+#node.name: "Franz Kafka"
+
+# Every node can be configured to allow or deny being eligible as the master,
+# and to allow or deny to store the data.
+#
+# Allow this node to be eligible as a master node (enabled by default):
+#
+#node.master: true
+#
+# Allow this node to store data (enabled by default):
+#
+#node.data: true
+
+# You can exploit these settings to design advanced cluster topologies.
+#
+# 1. You want this node to never become a master node, only to hold data.
+#    This will be the "workhorse" of your cluster.
+#
+#node.master: false
+#node.data: true
+#
+# 2. You want this node to only serve as a master: to not store any data and
+#    to have free resources. This will be the "coordinator" of your cluster.
+#
+#node.master: true
+#node.data: false
+#
+# 3. You want this node to be neither master nor data node, but
+#    to act as a "search load balancer" (fetching data from nodes,
+#    aggregating results, etc.)
+#
+#node.master: false
+#node.data: false
+
+# Use the Cluster Health API [http://localhost:9200/_cluster/health], the
+# Node Info API [http://localhost:9200/_nodes] or GUI tools
+# such as <http://www.elasticsearch.org/overview/marvel/>,
+# <http://github.com/karmi/elasticsearch-paramedic>,
+# <http://github.com/lukas-vlcek/bigdesk> and
+# <http://mobz.github.com/elasticsearch-head> to inspect the cluster state.
+
+# A node can have generic attributes associated with it, which can later be used
+# for customized shard allocation filtering, or allocation awareness. An attribute
+# is a simple key value pair, similar to node.key: value, here is an example:
+#
+#node.rack: rack314
+
+# By default, multiple nodes are allowed to start from the same installation location
+# to disable it, set the following:
+#node.max_local_storage_nodes: 1
+
+
+#################################### Index ####################################
+
+# You can set a number of options (such as shard/replica options, mapping
+# or analyzer definitions, translog settings, ...) for indices globally,
+# in this file.
+#
+# Note, that it makes more sense to configure index settings specifically for
+# a certain index, either when creating it or by using the index templates API.
+#
+# See <http://elasticsearch.org/guide/en/elasticsearch/reference/current/index-modules.html> and
+# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/indices-create-index.html>
+# for more information.
+
+# Set the number of shards (splits) of an index (5 by default):
+#
+index.number_of_shards: 1
+
+# Set the number of replicas (additional copies) of an index (1 by default):
+#
+index.number_of_replicas: 0
+
+# Note, that for development on a local machine, with small indices, it usually
+# makes sense to "disable" the distributed features:
+#
+#index.number_of_shards: 1
+#index.number_of_replicas: 0
+
+# These settings directly affect the performance of index and search operations
+# in your cluster. Assuming you have enough machines to hold shards and
+# replicas, the rule of thumb is:
+#
+# 1. Having more *shards* enhances the _indexing_ performance and allows to
+#    _distribute_ a big index across machines.
+# 2. Having more *replicas* enhances the _search_ performance and improves the
+#    cluster _availability_.
+#
+# The "number_of_shards" is a one-time setting for an index.
+#
+# The "number_of_replicas" can be increased or decreased anytime,
+# by using the Index Update Settings API.
+#
+# Elasticsearch takes care about load balancing, relocating, gathering the
+# results from nodes, etc. Experiment with different settings to fine-tune
+# your setup.
+
+# Use the Index Status API (<http://localhost:9200/A/_status>) to inspect
+# the index status.
+
+
+#################################### Paths ####################################
+
+# Path to directory containing configuration (this file and logging.yml):
+#
+#path.conf: /path/to/conf
+
+# Path to directory where to store index data allocated for this node.
+#
+#path.data: /path/to/data
+#
+# Can optionally include more than one location, causing data to be striped across
+# the locations (a la RAID 0) on a file level, favouring locations with most free
+# space on creation. For example:
+#
+#path.data: /path/to/data1,/path/to/data2
+
+# Path to temporary files:
+#
+#path.work: /path/to/work
+
+# Path to log files:
+#
+#path.logs: /path/to/logs
+
+# Path to where plugins are installed:
+#
+#path.plugins: /path/to/plugins
+
+
+#################################### Plugin ###################################
+
+# If a plugin listed here is not installed for current node, the node will not start.
+#
+#plugin.mandatory: mapper-attachments,lang-groovy
+
+
+################################### Memory ####################################
+
+# Elasticsearch performs poorly when JVM starts swapping: you should ensure that
+# it _never_ swaps.
+#
+# Set this property to true to lock the memory:
+#
+#bootstrap.mlockall: true
+
+# Make sure that the ES_MIN_MEM and ES_MAX_MEM environment variables are set
+# to the same value, and that the machine has enough memory to allocate
+# for Elasticsearch, leaving enough memory for the operating system itself.
+#
+# You should also make sure that the Elasticsearch process is allowed to lock
+# the memory, eg. by using `ulimit -l unlimited`.
+
+
+############################## Network And HTTP ###############################
+
+# Elasticsearch, by default, binds itself to the 0.0.0.0 address, and listens
+# on port [9200-9300] for HTTP traffic and on port [9300-9400] for node-to-node
+# communication. (the range means that if the port is busy, it will automatically
+# try the next port).
+
+# Set the bind address specifically (IPv4 or IPv6):
+#
+#network.bind_host: 192.168.0.1
+
+# Set the address other nodes will use to communicate with this node. If not
+# set, it is automatically derived. It must point to an actual IP address.
+#
+#network.publish_host: 192.168.0.1
+
+# Set both 'bind_host' and 'publish_host':
+#
+#network.host: 192.168.0.1
+
+# Set a custom port for the node to node communication (9300 by default):
+#
+#transport.tcp.port: 9300
+
+# Enable compression for all communication between nodes (disabled by default):
+#
+#transport.tcp.compress: true
+
+# Set a custom port to listen for HTTP traffic:
+#
+http.port: 9200
+
+# Set a custom allowed content length:
+#
+#http.max_content_length: 100mb
+
+# Disable HTTP completely:
+#
+#http.enabled: false
+
+
+################################### Gateway ###################################
+
+# The gateway allows for persisting the cluster state between full cluster
+# restarts. Every change to the state (such as adding an index) will be stored
+# in the gateway, and when the cluster starts up for the first time,
+# it will read its state from the gateway.
+
+# There are several types of gateway implementations. For more information, see
+# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/modules-gateway.html>.
+
+# The default gateway type is the "local" gateway (recommended):
+#
+#gateway.type: local
+
+# Settings below control how and when to start the initial recovery process on
+# a full cluster restart (to reuse as much local data as possible when using shared
+# gateway).
+
+# Allow recovery process after N nodes in a cluster are up:
+#
+gateway.recover_after_nodes: 1
+
+# Set the timeout to initiate the recovery process, once the N nodes
+# from previous setting are up (accepts time value):
+#
+#gateway.recover_after_time: 5m
+
+# Set how many nodes are expected in this cluster. Once these N nodes
+# are up (and recover_after_nodes is met), begin recovery process immediately
+# (without waiting for recover_after_time to expire):
+#
+gateway.expected_nodes: 1
+
+
+############################# Recovery Throttling #############################
+
+# These settings allow to control the process of shards allocation between
+# nodes during initial recovery, replica allocation, rebalancing,
+# or when adding and removing nodes.
+
+# Set the number of concurrent recoveries happening on a node:
+#
+# 1. During the initial recovery
+#
+#cluster.routing.allocation.node_initial_primaries_recoveries: 4
+#
+# 2. During adding/removing nodes, rebalancing, etc
+#
+#cluster.routing.allocation.node_concurrent_recoveries: 2
+
+# Set to throttle throughput when recovering (eg. 100mb, by default 20mb):
+#
+#indices.recovery.max_bytes_per_sec: 20mb
+
+# Set to limit the number of open concurrent streams when
+# recovering a shard from a peer:
+#
+#indices.recovery.concurrent_streams: 5
+
+
+################################## Discovery ##################################
+
+# Discovery infrastructure ensures nodes can be found within a cluster
+# and master node is elected. Multicast discovery is the default.
+
+# Set to ensure a node sees N other master eligible nodes to be considered
+# operational within the cluster. This should be set to a quorum/majority of
+# the master-eligible nodes in the cluster.
+#
+#discovery.zen.minimum_master_nodes: 1
+
+# Set the time to wait for ping responses from other nodes when discovering.
+# Set this option to a higher value on a slow or congested network
+# to minimize discovery failures:
+#
+#discovery.zen.ping.timeout: 3s
+
+# For more information, see
+# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/modules-discovery-zen.html>
+
+# Unicast discovery allows to explicitly control which nodes will be used
+# to discover the cluster. It can be used when multicast is not present,
+# or to restrict the cluster communication-wise.
+#
+# 1. Disable multicast discovery (enabled by default):
+#
+discovery.zen.ping.multicast.enabled: false
+discovery.zen.ping.unicast.enabled: true
+#
+# 2. Configure an initial list of master nodes in the cluster
+#    to perform discovery when new nodes (master or data) are started:
+#
+discovery.zen.ping.unicast.hosts: ["localhost"]
+
+# EC2 discovery allows to use AWS EC2 API in order to perform discovery.
+#
+# You have to install the cloud-aws plugin for enabling the EC2 discovery.
+#
+# For more information, see
+# <http://elasticsearch.org/guide/en/elasticsearch/reference/current/modules-discovery-ec2.html>
+#
+# See <http://elasticsearch.org/tutorials/elasticsearch-on-ec2/>
+# for a step-by-step tutorial.
+
+# GCE discovery allows to use Google Compute Engine API in order to perform discovery.
+#
+# You have to install the cloud-gce plugin for enabling the GCE discovery.
+#
+# For more information, see <https://github.com/elasticsearch/elasticsearch-cloud-gce>.
+
+# Azure discovery allows to use Azure API in order to perform discovery.
+#
+# You have to install the cloud-azure plugin for enabling the Azure discovery.
+#
+# For more information, see <https://github.com/elasticsearch/elasticsearch-cloud-azure>.
+
+################################## Slow Log ##################################
+
+# Shard level query and fetch threshold logging.
+
+#index.search.slowlog.threshold.query.warn: 10s
+#index.search.slowlog.threshold.query.info: 5s
+#index.search.slowlog.threshold.query.debug: 2s
+#index.search.slowlog.threshold.query.trace: 500ms
+
+#index.search.slowlog.threshold.fetch.warn: 1s
+#index.search.slowlog.threshold.fetch.info: 800ms
+#index.search.slowlog.threshold.fetch.debug: 500ms
+#index.search.slowlog.threshold.fetch.trace: 200ms
+
+#index.indexing.slowlog.threshold.index.warn: 10s
+#index.indexing.slowlog.threshold.index.info: 5s
+#index.indexing.slowlog.threshold.index.debug: 2s
+#index.indexing.slowlog.threshold.index.trace: 500ms
+
+################################## GC Logging ################################
+
+#monitor.jvm.gc.young.warn: 1000ms
+#monitor.jvm.gc.young.info: 700ms
+#monitor.jvm.gc.young.debug: 400ms
+
+#monitor.jvm.gc.old.warn: 10s
+#monitor.jvm.gc.old.info: 5s
+#monitor.jvm.gc.old.debug: 2s
+
+################################## Security ################################
+
+# Uncomment if you want to enable JSONP as a valid return transport on the
+# http server. With this enabled, it may pose a security risk, so disabling
+# it unless you need it is recommended (it is disabled by default).
+#
+#http.jsonp.enable: true

--- a/org/alien4cloud/elasticsearch/centos/config/elasticsearch/logging.yml
+++ b/org/alien4cloud/elasticsearch/centos/config/elasticsearch/logging.yml
@@ -1,0 +1,56 @@
+# you can override this using by setting a system property, for example -Des.logger.level=DEBUG
+es.logger.level: INFO
+rootLogger: ${es.logger.level}, console, file
+logger:
+  # log action execution errors for easier debugging
+  action: DEBUG
+  # reduce the logging for aws, too much is logged under the default INFO
+  com.amazonaws: WARN
+
+  # gateway
+  #gateway: DEBUG
+  #index.gateway: DEBUG
+
+  # peer shard recovery
+  #indices.recovery: DEBUG
+
+  # discovery
+  #discovery: TRACE
+
+  index.search.slowlog: TRACE, index_search_slow_log_file
+  index.indexing.slowlog: TRACE, index_indexing_slow_log_file
+
+additivity:
+  index.search.slowlog: false
+  index.indexing.slowlog: false
+
+appender:
+  console:
+    type: console
+    layout:
+      type: consolePattern
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
+
+  file:
+    type: dailyRollingFile
+    file: ${path.logs}/ELS-${cluster.name}.log
+    datePattern: "'.'yyyy-MM-dd"
+    layout:
+      type: pattern
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
+
+  index_search_slow_log_file:
+    type: dailyRollingFile
+    file: ${path.logs}/ELS-${cluster.name}_index_search_slowlog.log
+    datePattern: "'.'yyyy-MM-dd"
+    layout:
+      type: pattern
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
+
+  index_indexing_slow_log_file:
+    type: dailyRollingFile
+    file: ${path.logs}/ELS-${cluster.name}_index_indexing_slowlog.log
+    datePattern: "'.'yyyy-MM-dd"
+    layout:
+      type: pattern
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"

--- a/org/alien4cloud/elasticsearch/centos/scripts/commons/commons.sh
+++ b/org/alien4cloud/elasticsearch/centos/scripts/commons/commons.sh
@@ -1,0 +1,207 @@
+#!/bin/bash -e
+
+echo "Loading commons"
+
+# Ensure that the last executed operation has been successfully executed, exit with error if not.
+#
+# args:
+# $1 operation description (just for logs).
+ensure_success() {
+  if [ "$?" -ne 0 ]; then
+    echo "The following operation failed ! Aborting : $1" >&2;
+    exit 1;
+  else
+    echo "The following operation succeed: $1";
+  fi
+}
+
+# Download the file using the available download command: wget or curl.
+#
+# args:
+# $1 download description.
+# $2 download link.
+# $3 output file.
+download() {
+  echo "Will download $1 from $2 into $3"
+
+  if [ -f /usr/bin/wget ]; then
+    DOWNLOADER="wget"
+  elif [ -f /usr/bin/curl ]; then
+    DOWNLOADER="curl"
+  fi
+
+  if [ "$DOWNLOADER" = "wget" ];then
+    Q_FLAG="--no-check-certificate -q"
+    O_FLAG="-O"
+    LINK_FLAG=""
+  elif [ "$DOWNLOADER" = "curl" ];then
+    Q_FLAG="-ks"
+    O_FLAG="-Lo"
+    LINK_FLAG="-O"
+  else
+    echo "Nor wget or curl is present, can't download anything, aborting !" >&2
+    exit 1
+  fi
+  echo "Downloading using command: $DOWNLOADER $Q_FLAG $O_FLAG $3 $LINK_FLAG $2"
+  sudo $DOWNLOADER $Q_FLAG $O_FLAG $3 $LINK_FLAG $2 >/dev/null 2>&1
+  ensure_success "Downloading using command: $DOWNLOADER $Q_FLAG $O_FLAG $3 $LINK_FLAG $2"
+}
+
+# Try to guess the Operating System distribution
+# The guessing algorithm is:
+#   1- use lsb_release retrieve the distribution name (should normally be present it's listed as requirement of VM images in installation guide)
+#   2- If lsb_release is not present check if yum is present. If yes assume that we are running Centos
+#   3- Otherwise check if apt-get is present. If yes assume that we are running Ubuntu
+#   4- Otherwise give-up and return "unknown"
+#
+# Any way the returned string is in lower case.
+# This function prints the result to the std output so you should use the following form to retrieve it:
+# os_dist="$(get_os_distribution)"
+get_os_distribution () {
+  rname="unknown"
+  if  [[ "$(which lsb_release)" != "" ]]
+    then
+    rname=$(lsb_release -si | tr [:upper:] [:lower:])
+  else
+    if [[ "$(which yum)" != "" ]]
+      then
+      # assuming we are on Centos
+      rname="centos"
+    elif [[ "$(which apt-get)" != "" ]]
+      then
+      # assuming we are on Ubuntu
+      rname="ubuntu"
+    fi
+  fi
+  echo ${rname}
+}
+
+install_packages() {
+  packages_to_install="$*"
+  echo "Installing packages ${packages_to_install}"
+  case "$(get_os_distribution)" in
+    "ubuntu" | "debian" | "mint")
+    LOCK="/tmp/lockaptget"
+
+    while true; do
+      if mkdir "${LOCK}" &>/dev/null; then
+        echo "take apt lock"
+        #echo "$$>${LOCK}/pid"
+        break;
+      fi
+      echo "waiting apt lock to be released..."
+      sleep 2
+    done
+    while sudo fuser /var/lib/dpkg/lock >/dev/null 2>&1 ; do
+      echo "$NAME waiting for other software managers to finish..."
+      sleep 2
+    done
+    sudo apt-get -y update > /dev/null 2>&1
+    sudo apt-get -y install ${packages_to_install} > /dev/null 2>&1
+    rm -rf "${LOCK}"
+    echo "released apt lock"
+    ;;
+    "centos" | "redhat" | "fedora")
+    sudo yum install -y install ${packages_to_install}
+    ;;
+  esac
+}
+
+# Check that this env var is not empty (and fail if it's empty).
+#
+# args:
+# $1 the env var name
+require_env () {
+  VAR_NAME=$1
+  if [ ! "${!VAR_NAME}" ]; then
+    echo "==========================================================" >&2
+    echo "Required env var <$VAR_NAME> not found ! Aborting" >&2
+    echo "==========================================================" >&2
+    exit 1
+  else
+    echo "The value for required var <$VAR_NAME> is: ${!VAR_NAME}"
+  fi
+}
+
+# Check that the csv list of env vars are not empty (fail if one is empty).
+#
+# args:
+# $1 comma or space separated list of env variable names
+require_envs () {
+  VAR_LIST=$1
+  for VAR_NAME in $(echo ${VAR_LIST} | tr ',' ' ')
+  do
+    require_env ${VAR_NAME}
+  done
+}
+
+# Eval the config file and replace the listed env vars.
+# Variables are expected to apear in mode %VAR_NAME% in source file.
+# It will not work if VAR_NAME or VAR_VALUE contains '@' (but will if they contain '/' !)
+#
+# args:
+# $1 the source file location
+# $2 the destination file location
+# $1 the list of environment variable to replace
+eval_conf_file () {
+  SRC_FILE=$1
+  DEST_FILE=$2
+  VAR_LIST=$3
+
+  sudo cp $SRC_FILE $DEST_FILE
+  if [ ! -z "$VAR_LIST" ]; then
+    for VAR_NAME in $(echo ${VAR_LIST} | tr ',' ' ')
+    do
+      VAR_VALUE="${!VAR_NAME}"
+      sudo sed -i -e "s@%${VAR_NAME}%@${VAR_VALUE}@g" $DEST_FILE
+    done
+  fi
+  echo "Content of $DEST_FILE"
+  sudo cat $DEST_FILE
+}
+
+# Ensure that the list of binaries are found on the system, fail if on is not found.
+#
+# args:
+# $1 space separated list of binaries
+require_bin () {
+  BIN_LIST=$*
+  for BIN_NAME in ${BIN_LIST};
+  do
+    if ! [ -x "$(command -v ${BIN_NAME})" ]; then
+      echo "==========================================================" >&2
+      echo "${BIN_NAME} is not installed." >&2
+      echo "==========================================================" >&2
+      exit 1
+    else
+      echo "${BIN_NAME} is installed"
+    fi
+  done
+}
+
+# Ensure that the list of dependency packages are found on the system,
+# Install those that are not found using the right package manager (apt-get or yum).
+#
+# args:
+# $1 space separated list of packages
+install_dependencies() {
+  PACKAGE_NAMES=$*
+  PACKAGES_TO_INSTALL=""
+  for BIN_NAME in ${PACKAGE_NAMES};
+  do
+    if ! [ -x "$(command -v ${BIN_NAME})" ]; then
+      echo "${BIN_NAME} was not found, I will install it"
+      PACKAGES_TO_INSTALL="${PACKAGES_TO_INSTALL} ${BIN_NAME}"
+    else
+      echo "${BIN_NAME} was found, will not install it"
+    fi
+  done
+  if [ "${PACKAGES_TO_INSTALL}" ]; then
+    echo "I finally will install: ${PACKAGES_TO_INSTALL}"
+    install_packages ${PACKAGES_TO_INSTALL}
+  else
+    echo "Nothing to install so far !"
+  fi
+}
+
+echo "commons loaded"

--- a/org/alien4cloud/elasticsearch/centos/scripts/elasticsearch/configure_elasticsearch.sh
+++ b/org/alien4cloud/elasticsearch/centos/scripts/elasticsearch/configure_elasticsearch.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -e
+
+# set the cluster name
+sudo sed -i -e "s/cluster\.name\: \(.*\)$i/cluster\.name\: $CLUSTER_NAME/g" /etc/elasticsearch/elasticsearch.yml
+# st the http port
+sudo sed -i -e "s/http\.port\: \(.*\)$i/http\.port\: $HTTP_PORT/g" /etc/elasticsearch/elasticsearch.yml
+
+# Count the number of replicas
+number_of_replicas=$((0))
+es_ips=""
+for i in $(echo ${INSTANCES} | tr ',' ' ')
+do
+	varname="${i}_ES_IP"
+	if [ "${i}" != "${INSTANCE}" ]; then
+		echo "Detected another instance of ES with ip ${!varname}"
+		if [ "${number_of_replicas}" -gt "0" ]; then
+			es_ips="${es_ips}, "
+		fi
+		es_ips="${es_ips}\"${!varname}\""
+		echo "List of replicas ips is now ${es_ips}"
+		number_of_replicas=$((number_of_replicas + 1))
+		echo "Number of replicas is now ${number_of_replicas}"
+	fi
+done
+
+echo "List of replicas ips is finally ${es_ips}"
+echo "Number of replicas is finally ${number_of_replicas}"
+
+# Set the hosts if we have replicas
+if [ "$number_of_replicas" -gt "0" ]; then
+	sudo sed -i -e "s/discovery\.zen\.ping\.unicast\.hosts\: \[\(.*\)\]/discovery\.zen\.ping\.unicast\.hosts\: \[\1, $es_ips\]/g" /etc/elasticsearch/elasticsearch.yml
+fi
+
+# Set the number of replicas
+export i=`cat /etc/elasticsearch/elasticsearch.yml | grep index.number_of_replicas | grep -v "#" | cut -d":" -f2 | xargs`
+# TODO: add i + number_of_replicas
+sudo sed -i -e "s/index\.number_of_replicas\: $i/index\.number_of_replicas\: $number_of_replicas/g" /etc/elasticsearch/elasticsearch.yml

--- a/org/alien4cloud/elasticsearch/centos/scripts/elasticsearch/install_elasticsearch.sh
+++ b/org/alien4cloud/elasticsearch/centos/scripts/elasticsearch/install_elasticsearch.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -e
+source $commons/commons.sh
+
+
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+# OS configuration
+sudo bash -c "echo 'vm.overcommit_memory=0' >> /etc/sysctl.conf"
+sudo sysctl -p
+
+openLimit=65535
+sudo bash -c "echo 'elasticsearch         hard    nofile      $openLimit
+elasticsearch         soft    nofile      $openLimit
+' >> /etc/security/limits.conf"
+
+# Download the application and install elasticsearch
+download "ElasticSearch" "${APPLICATION_URL}" "elasticsearch.rpm"
+
+while sudo fuser /var/lib/dpkg/lock >/dev/null 2>&1 ; 
+do
+	echo "$NAME waiting for other software managers to finish..."
+  sleep 2
+done
+sudo rpm --install elasticsearch.rpm
+
+# Update configuration
+sudo bash -c "cat $configs/elasticsearch.yml > /etc/elasticsearch/elasticsearch.yml"
+sudo bash -c "cat $configs/logging.yml > /etc/elasticsearch/logging.yml"
+
+# change defaults
+sudo bash -c "echo 'ES_USE_GC_LOGGING=y' >> /etc/default/elasticsearch"
+sudo bash -c "echo 'export ES_USE_GC_LOGGING' >> /etc/default/elasticsearch"
+sudo bash -c "echo 'ES_JAVA_OPTS=-XX:+PrintGCDateStamps' >> /etc/default/elasticsearch"
+sudo bash -c "echo 'ES_HEAP_SIZE=1g' >> /etc/default/elasticsearch"
+
+# Configure init script and start elasticsearch
+sudo chkconfig elasticsearch on

--- a/org/alien4cloud/elasticsearch/centos/scripts/elasticsearch/start_elasticsearch.sh
+++ b/org/alien4cloud/elasticsearch/centos/scripts/elasticsearch/start_elasticsearch.sh
@@ -1,0 +1,2 @@
+#!/bin/bash -e
+sudo /etc/init.d/elasticsearch start

--- a/org/alien4cloud/elasticsearch/centos/types.yml
+++ b/org/alien4cloud/elasticsearch/centos/types.yml
@@ -1,0 +1,71 @@
+tosca_definitions_version: alien_dsl_2_0_0
+
+metadata:
+  template_name: org.alien4cloud.elasticsearch.centos
+  template_version: 2.0.0-SNAPSHOT
+  template_author: alien4cloud
+
+imports:
+  - tosca-normative-types:1.0.0-ALIEN20
+  - org.alien4cloud.java.jdk.linux:2.0.0-SNAPSHOT
+  - org.alien4cloud.elasticsearch.pub:2.0.0-SNAPSHOT
+
+node_types:
+
+  org.alien4cloud.elasticsearch.centos.nodes.ElasticSearch:
+    derived_from: org.alien4cloud.elasticsearch.pub.nodes.ElasticSearchService
+    description: >
+      Installation of replicated ElasticSearch (if this node is scaled, will be replicated).
+    properties:
+      component_version:
+        description: The version of Elasticsearch
+        type: version
+        default: 1.7.0
+        constraints:
+          - valid_values: [ "1.7.0" ]
+      elasticsearch_url:
+        type: string
+        required: true
+        default: "https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.0.noarch.rpm"
+      cluster_name:
+        description: The name of the ElasticSearch cluster.
+        type: string
+        required: true
+        default: "escluster"
+    # This node is hosted on JDK, how can I express the fact that is must be hosted also on a ubuntu compute ?
+    # Need for some inheritance in container capability ...
+    #
+    # requirements:
+    #   - host:
+    #       capability: tosca.capabilities.Container
+    #       node: tosca.nodes.Compute
+    #       relationship: tosca.relationships.HostedOn
+    #       occurrences: [1, 1]
+    #       node_filter:
+    #         capabilities:
+    #           - tosca.capabilities.OperatingSystem:
+    #               properties:
+    #                 - type: { equal: linux }
+    #                 - architecture: { equal: x86_64 }
+    #                 - distribution: { valid_values: [ "ubuntu", "debian" ] }
+    interfaces:
+      Standard:
+        create:
+          inputs:
+            APPLICATION_URL: { get_property: [SELF, elasticsearch_url] }
+          implementation: scripts/elasticsearch/install_elasticsearch.sh
+        configure:
+          inputs:
+            ES_IP: { get_attribute: [HOST, ip_address] }
+            CLUSTER_NAME: { get_property: [SELF, cluster_name] }
+            HTTP_PORT: { get_property: [SELF, http, port] }
+          implementation: scripts/elasticsearch/configure_elasticsearch.sh
+        start:
+          implementation: scripts/elasticsearch/start_elasticsearch.sh
+    artifacts:
+      - configs:
+          file: config/elasticsearch
+          type: tosca.artifacts.File
+      - commons:
+          file: scripts/commons
+          type: tosca.artifacts.File


### PR DESCRIPTION
The current scripts for elasticsearch cannot work on Centos, so I added a new centos subtype of elasticsearch in order to be deployed on it (and other rpm based os ?)