### PR TITLE
Refactor port property in Consul API Endpoint

### DIFF
--- a/org/alien4cloud/alien4cloud/topologies/a4c_ha/type.yml
+++ b/org/alien4cloud/alien4cloud/topologies/a4c_ha/type.yml
@@ -70,7 +70,7 @@ topology_template:
       capabilities:
         consul_agent:
           properties:
-            api_port: 8500
+            port: 8500
     Alien4Cloud:
       type: org.alien4cloud.alien4cloud.webapp.nodes.Alien4Cloud
       properties:
@@ -136,7 +136,7 @@ topology_template:
       capabilities:
         consul_agent:
           properties:
-            api_port: 8500
+            port: 8500
     AlienCompute:
       type: tosca.nodes.Compute
       capabilities:
@@ -213,7 +213,7 @@ topology_template:
       capabilities:
         consul_agent:
           properties:
-            api_port: 8500
+            port: 8500
     ConsulTemplate4Nginx:
       type: org.alien4cloud.nginx.nginx_sh.nodes.ConsulTemplate4Nginx
       properties:

--- a/org/alien4cloud/alien4cloud/webapp/types.yml
+++ b/org/alien4cloud/alien4cloud/webapp/types.yml
@@ -164,7 +164,7 @@ relationship_types:
             TLS_ENABLED: { get_property: [SOURCE, consul, tls_enabled] }
             CA_PASSPHRASE: { get_property: [SOURCE, consul, ca_passphrase] }
             AGENT_IP: { get_attribute: [TARGET, ip_address] }
-            AGENT_API_PORT: { get_property: [TARGET, consul_agent, api_port] }
+            AGENT_API_PORT: { get_property: [TARGET, consul_agent, port] }
           implementation: scripts/ConnectToConsulAgent/pre_configure_source.sh
     artifacts:
       - ssl:

--- a/org/alien4cloud/consul/consul_sh/type.yml
+++ b/org/alien4cloud/consul/consul_sh/type.yml
@@ -78,7 +78,7 @@ node_types:
             CONSUL_AGENT_MODE: { get_property: [SELF, agent_mode] }
             CONSUL_DATA_DIR: { get_property: [SELF, data_dir] }
             CONSUL_BIND_ADDRESS: { get_attribute: [HOST, ip_address] }
-            CONSUL_API_PORT: { get_property: [SELF, consul_agent, api_port] }
+            CONSUL_API_PORT: { get_property: [SELF, consul_agent, port] }
             TLS_ENABLED: { get_property: [SELF, tls_enabled] }
             CA_PASSPHRASE: { get_property: [SELF, ca_passphrase] }
             ENCRYPT_KEY: { get_property: [SELF, encrypt_key] }
@@ -125,7 +125,7 @@ node_types:
             CONSUL_AGENT_MODE: { get_property: [SELF, agent_mode] }
             CONSUL_DATA_DIR: { get_property: [SELF, data_dir] }
             CONSUL_BIND_ADDRESS: { get_attribute: [HOST, ip_address] }
-            CONSUL_API_PORT: { get_property: [SELF, consul_agent, api_port] }
+            CONSUL_API_PORT: { get_property: [SELF, consul_agent, port] }
             TLS_ENABLED: { get_property: [SELF, tls_enabled] }
             CA_PASSPHRASE: { get_property: [SELF, ca_passphrase] }
             ENCRYPT_KEY: { get_property: [SELF, encrypt_key] }

--- a/org/alien4cloud/consul/pub/types.yml
+++ b/org/alien4cloud/consul/pub/types.yml
@@ -72,7 +72,7 @@ capability_types:
     description: >
       A consul agent (server or client) exposes this capability.
     properties:
-      api_port:
+      port:
         type: integer
         description: Port for http/https API.
         required: true

--- a/org/alien4cloud/vault/topologies/vault_production/vault_prod_topology.yaml
+++ b/org/alien4cloud/vault/topologies/vault_production/vault_prod_topology.yaml
@@ -53,7 +53,7 @@ topology_template:
       capabilities:
         consul_agent:
           properties:
-            api_port: 8500
+            port: 8500
             protocol: tcp
             secure: true
             network_name: PRIVATE

--- a/org/alien4cloud/vault/vault_sh/type.yml
+++ b/org/alien4cloud/vault/vault_sh/type.yml
@@ -141,7 +141,7 @@ relationship_types:
         pre_configure_source:
           inputs:
             AGENT_IP: { get_attribute: [TARGET, ip_address] }
-            AGENT_API_PORT: { get_property: [TARGET, consul_agent, api_port] }
+            AGENT_API_PORT: { get_property: [TARGET, consul_agent, port] }
             VAULT_IP: { get_attribute: [SOURCE, ip_address] }
             VAULT_PORT: { get_property: [SOURCE, port] }
           implementation: scripts/vault/configure_vault.sh


### PR DESCRIPTION
Use the normative property "port" from the tosca.capabilities.Endpoint instead of defining a new "api_port" for Consul endpoint.

The idea behind doing that is that I can't see any valid reason to not use the normative property. It will make it easier to integrate with other types that expect the port property to be used instead.