### PR TITLE
derive ConsulServer capability from ConsulAgent

### DIFF
--- a/org/alien4cloud/consul/pub/types.yml
+++ b/org/alien4cloud/consul/pub/types.yml
@@ -92,6 +92,6 @@ capability_types:
         description: the passphrase for the CA certificate
         required: false
   org.alien4cloud.consul.pub.capabilities.ConsulServer:
-    derived_from: tosca.capabilities.Root
+    derived_from: org.alien4cloud.consul.pub.capabilities.ConsulAgent
     description: >
       Exposed by a consul server agent.


### PR DESCRIPTION
I want to add an input in a relationship that get the ip_address of the consul server from the consul_server capability. 

```yaml
  org.ystia.yorc.experimental.consul.linux.ansible.relationships.JoinServer:
    derived_from: tosca.relationships.ConnectsTo
    description: >
      Connects a Consul agent to a Consul server
    valid_target_types: [ org.ystia.yorc.experimental.consul.pub.capabilities.ConsulServer ]
    interfaces:
      Configure:
        pre_configure_source:
          inputs:
            SERVER_IP: { get_attribute: [TARGET, consul_server, ip_address] }
          implementation: playbooks/consul_connects_agent_to_server.yml
```

In yorc, in order to get the ip_address attribute **from a capability**, we need that the `consul_server` capability is a derived of `tosca.capabilities.Endpoint`.

We have a workaround, and instead of having : `get_attribute: [TARGET, consul_server, ip_address]` we can use `get_attribute: [TARGET, ip_address]` to get it directly from the host. But then our consul server component can not be used as an alien4cloud service. Indeed, only capabilities can be exposed in a service. 

Here I think that this capability should be a derived of the ConsulAgent capability, but if you think that it should not, we can just make it a derivee of tosca.capabilities.Endpoint.

@loicalbertin 


