### PR TITLE
A4C component REST API default port is 8088

### DIFF
--- a/org/alien4cloud/alien4cloud/pub/types.yml
+++ b/org/alien4cloud/alien4cloud/pub/types.yml
@@ -58,7 +58,7 @@ capability_types:
         type: integer
         description: The port of the alien HTTP endpoint.
         required: true
-        default: 8080
+        default: 8088
         constraints:
           - in_range: [ 1, 65535 ]
       protocol:


### PR DESCRIPTION
When installing the A4C app, the default port is 8088.
In this type, the default port is set to 8080. Both are not coherent. This PR to update it.