### PR TITLE
Bugfix/a4c secured

### DIFF
--- a/org/alien4cloud/alien4cloud/config/location/playbook/create_location.yml
+++ b/org/alien4cloud/alien4cloud/config/location/playbook/create_location.yml
@@ -1,7 +1,6 @@
 ---
 - hosts: all
   name: Create an orchestrator location
-  become: true
 
   roles:
     - create_location

--- a/org/alien4cloud/alien4cloud/config/location_resources/on_demand/playbook/create_location_resources.yml
+++ b/org/alien4cloud/alien4cloud/config/location_resources/on_demand/playbook/create_location_resources.yml
@@ -1,7 +1,6 @@
 ---
 - hosts: all
   name: Add AWS on-demand resource on an orchestrator resource
-  become: true
 
   pre_tasks:
     - name: Debug vars

--- a/org/alien4cloud/alien4cloud/webapp/scripts/alien/config_alien.sh
+++ b/org/alien4cloud/alien4cloud/webapp/scripts/alien/config_alien.sh
@@ -26,7 +26,7 @@ if [ "$SERVER_PROTOCOL" == "https" ]; then
   SERVER_KEYSTORE_PWD="changeit"
   KEY_PWD="${SERVER_KEYSTORE_PWD}"
 
-  TMP_SSL_DIR=$( generateKeyAndStore "alient4cloud.org" "server" "${SERVER_KEYSTORE_PWD}" "${ALIEN_IP}" )
+  TMP_SSL_DIR=$( generateKeyAndStore "alient4cloud.org" "server" "${SERVER_KEYSTORE_PWD}" "${ALIEN_IP}" "${ALIEN_PUBLIC_ADDRESS}")
 
   AC4_SSL_DIR=/etc/alien4cloud/ssl
   sudo mkdir -p $AC4_SSL_DIR

--- a/org/alien4cloud/alien4cloud/webapp/scripts/alien/config_alien.sh
+++ b/org/alien4cloud/alien4cloud/webapp/scripts/alien/config_alien.sh
@@ -20,7 +20,7 @@ sudo sed -i "s/username: admin/username: ${ADMIN_USERNAME}/g" ${A4C_CONFIG}
 if [ "$SERVER_PROTOCOL" == "https" ]; then
   echo "Activating ssl endpoint for Alien webapp"
   # enable SSL
-  sudo sed -i -e "s/#  ssl\:/ssl\:/g" ${A4C_CONFIG}
+  sudo sed -i -e "s/#  ssl\:/  ssl\:/g" ${A4C_CONFIG}
 
   # FIXME: can't be different !!! some confusion somewhere ?
   SERVER_KEYSTORE_PWD="changeit"
@@ -38,9 +38,9 @@ if [ "$SERVER_PROTOCOL" == "https" ]; then
 
   sudo rm -rf $TMP_SSL_DIR
 
-  sudo sed -i -e "s@#    key-store\: \(.*\)@  key-store\: \"$AC4_SSL_DIR/server-keystore.jks\"@g" ${A4C_CONFIG}
-  sudo sed -i -e "s/#    key-store-password\: \(.*\)/  key-store-password\: \"$SERVER_KEYSTORE_PWD\"/g" ${A4C_CONFIG}
-  sudo sed -i -e "s/#    key-password\: \(.*\)/  key-password\: \"$KEY_PWD\"/g" ${A4C_CONFIG}
+  sudo sed -i -e "s@#    key-store\: \(.*\)@    key-store\: \"$AC4_SSL_DIR/server-keystore.jks\"@g" ${A4C_CONFIG}
+  sudo sed -i -e "s/#    key-store-password\: \(.*\)/    key-store-password\: \"$SERVER_KEYSTORE_PWD\"/g" ${A4C_CONFIG}
+  sudo sed -i -e "s/#    key-password\: \(.*\)/    key-password\: \"$KEY_PWD\"/g" ${A4C_CONFIG}
 fi
 
 # get the ES address list

--- a/org/alien4cloud/alien4cloud/webapp/scripts/alien/config_alien.sh
+++ b/org/alien4cloud/alien4cloud/webapp/scripts/alien/config_alien.sh
@@ -79,13 +79,6 @@ if [ -d "/tmp/a4c/work/${NODE}/ConnectToConsulAgent" ]; then
   sudo sed -i -e "\$a\ \ consulAgentPort: ${AGENT_API_PORT}" ${A4C_CONFIG}
   # set the alien IP for consul checks
   sudo sed -i -e "\$a\ \ instanceIp: ${ALIEN_IP}" ${A4C_CONFIG}
-  # sudo sed -i -e "s/ha_enabled\: \(.*\)/ha_enabled\: true/g" ${A4C_CONFIG}
-  # sudo sed -i -e "s/consulAgentIp\: \(.*\)/consulAgentIp\: ${AGENT_IP}/g" ${A4C_CONFIG}
-  # sudo sed -i -e "s/consulAgentPort\: \(.*\)/consulAgentPort\: ${AGENT_API_PORT}/g" ${A4C_CONFIG}
-  # sudo sed -i -e "s/#\(.*\)consulAgentIp\: \(.*\)/consulAgentIp\: ${AGENT_IP}/g" ${A4C_CONFIG}
-  # sudo sed -i -e "s/#\(.*\)consulAgentPort\: \(.*\)/consulAgentPort\: ${AGENT_API_PORT}/g" ${A4C_CONFIG}
-  # set the alien IP for consul checks
-  # sudo sed -i -e "s/instanceIp\: \(.*\)/instanceIp\: $ALIEN_IP/g" ${A4C_CONFIG}
 
   TLS_ENABLED=$(</tmp/a4c/work/${NODE}/ConnectToConsulAgent/TLSEnabled)
   if [ "$TLS_ENABLED" == "true" ]; then
@@ -120,12 +113,6 @@ if [ -d "/tmp/a4c/work/${NODE}/ConnectToConsulAgent" ]; then
       sudo sed -i -e "\$a\ \ trustStorePwd:  changeit" ${A4C_CONFIG}
       sudo sed -i -e "\$a\ \ serverProtocol: https" ${A4C_CONFIG}
 
-      # sudo sed -i -e "s/consul_tls_enabled\: \(.*\)/consul_tls_enabled\: true/g" ${A4C_CONFIG}
-      # sudo sed -i -e "s@keyStorePath\: \(.*\)@keyStorePath\: $SSL_STORE_PATH/client-keystore.jks@g" ${A4C_CONFIG}
-      # sudo sed -i -e "s@trustStorePath\: \(.*\)@trustStorePath\: $SSL_STORE_PATH/truststore.jks@g" ${A4C_CONFIG}
-      # sudo sed -i -e "s/keyStoresPwd\: \(.*\)/keyStoresPwd\: changeit/g" ${A4C_CONFIG}
-      # sudo sed -i -e "s/keyStorePwd\: \(.*\)/keyStorePwd\: changeit/g" ${A4C_CONFIG}
-      # sudo sed -i -e "s/trustStorePwd\: \(.*\)/trustStorePwd\: changeit/g" ${A4C_CONFIG}
   else
       sudo sed -i -e "s/consul_tls_enabled\: \(.*\)/consul_tls_enabled\: false/g" ${A4C_CONFIG}
   fi

--- a/org/alien4cloud/alien4cloud/webapp/scripts/alien/config_alien.sh
+++ b/org/alien4cloud/alien4cloud/webapp/scripts/alien/config_alien.sh
@@ -73,13 +73,19 @@ if [ -d "/tmp/a4c/work/${NODE}/ConnectToConsulAgent" ]; then
   AGENT_IP=$(</tmp/a4c/work/${NODE}/ConnectToConsulAgent/agentIp)
 
   echo "A4C is connected to Consul ${AGENT_IP}:${AGENT_API_PORT}, activate HA"
-  sudo sed -i -e "s/ha_enabled\: \(.*\)/ha_enabled\: true/g" ${A4C_CONFIG}
-  sudo sed -i -e "s/consulAgentIp\: \(.*\)/consulAgentIp\: ${AGENT_IP}/g" ${A4C_CONFIG}
-  sudo sed -i -e "s/consulAgentPort\: \(.*\)/consulAgentPort\: ${AGENT_API_PORT}/g" ${A4C_CONFIG}
-  sudo sed -i -e "s/#\(.*\)consulAgentIp\: \(.*\)/consulAgentIp\: ${AGENT_IP}/g" ${A4C_CONFIG}
-  sudo sed -i -e "s/#\(.*\)consulAgentPort\: \(.*\)/consulAgentPort\: ${AGENT_API_PORT}/g" ${A4C_CONFIG}
+  sudo sed -i -e "\$aha:" ${A4C_CONFIG}
+  sudo sed -i -e "\$a\ \ ha_enabled: true" ${A4C_CONFIG}
+  sudo sed -i -e "\$a\ \ consulAgentIp: ${AGENT_IP}" ${A4C_CONFIG}
+  sudo sed -i -e "\$a\ \ consulAgentPort: ${AGENT_API_PORT}" ${A4C_CONFIG}
   # set the alien IP for consul checks
-  sudo sed -i -e "s/instanceIp\: \(.*\)/instanceIp\: $ALIEN_IP/g" ${A4C_CONFIG}
+  sudo sed -i -e "\$a\ \ instanceIp: ${ALIEN_IP}" ${A4C_CONFIG}
+  # sudo sed -i -e "s/ha_enabled\: \(.*\)/ha_enabled\: true/g" ${A4C_CONFIG}
+  # sudo sed -i -e "s/consulAgentIp\: \(.*\)/consulAgentIp\: ${AGENT_IP}/g" ${A4C_CONFIG}
+  # sudo sed -i -e "s/consulAgentPort\: \(.*\)/consulAgentPort\: ${AGENT_API_PORT}/g" ${A4C_CONFIG}
+  # sudo sed -i -e "s/#\(.*\)consulAgentIp\: \(.*\)/consulAgentIp\: ${AGENT_IP}/g" ${A4C_CONFIG}
+  # sudo sed -i -e "s/#\(.*\)consulAgentPort\: \(.*\)/consulAgentPort\: ${AGENT_API_PORT}/g" ${A4C_CONFIG}
+  # set the alien IP for consul checks
+  # sudo sed -i -e "s/instanceIp\: \(.*\)/instanceIp\: $ALIEN_IP/g" ${A4C_CONFIG}
 
   TLS_ENABLED=$(</tmp/a4c/work/${NODE}/ConnectToConsulAgent/TLSEnabled)
   if [ "$TLS_ENABLED" == "true" ]; then
@@ -106,12 +112,20 @@ if [ -d "/tmp/a4c/work/${NODE}/ConnectToConsulAgent" ]; then
 
       # FIXME: for the moment the securised client agent only listen on 127.0.0.1
       sudo sed -i -e "s/consulAgentIp\: \(.*\)/consulAgentIp\: 127.0.0.1/g" ${A4C_CONFIG}
-      sudo sed -i -e "s/consul_tls_enabled\: \(.*\)/consul_tls_enabled\: true/g" ${A4C_CONFIG}
-      sudo sed -i -e "s@keyStorePath\: \(.*\)@keyStorePath\: $SSL_STORE_PATH/client-keystore.jks@g" ${A4C_CONFIG}
-      sudo sed -i -e "s@trustStorePath\: \(.*\)@trustStorePath\: $SSL_STORE_PATH/truststore.jks@g" ${A4C_CONFIG}
-      sudo sed -i -e "s/keyStoresPwd\: \(.*\)/keyStoresPwd\: changeit/g" ${A4C_CONFIG}
-      sudo sed -i -e "s/keyStorePwd\: \(.*\)/keyStorePwd\: changeit/g" ${A4C_CONFIG}
-      sudo sed -i -e "s/trustStorePwd\: \(.*\)/trustStorePwd\: changeit/g" ${A4C_CONFIG}
+
+      sudo sed -i -e "\$a\ \ consul_tls_enabled: true" ${A4C_CONFIG}
+      sudo sed -i -e "\$a\ \ keyStorePath: $SSL_STORE_PATH/client-keystore.jks" ${A4C_CONFIG}
+      sudo sed -i -e "\$a\ \ keyStorePwd: changeit" ${A4C_CONFIG}
+      sudo sed -i -e "\$a\ \ trustStorePath: $SSL_STORE_PATH/truststore.jks" ${A4C_CONFIG}
+      sudo sed -i -e "\$a\ \ trustStorePwd:  changeit" ${A4C_CONFIG}
+      sudo sed -i -e "\$a\ \ serverProtocol: https" ${A4C_CONFIG}
+
+      # sudo sed -i -e "s/consul_tls_enabled\: \(.*\)/consul_tls_enabled\: true/g" ${A4C_CONFIG}
+      # sudo sed -i -e "s@keyStorePath\: \(.*\)@keyStorePath\: $SSL_STORE_PATH/client-keystore.jks@g" ${A4C_CONFIG}
+      # sudo sed -i -e "s@trustStorePath\: \(.*\)@trustStorePath\: $SSL_STORE_PATH/truststore.jks@g" ${A4C_CONFIG}
+      # sudo sed -i -e "s/keyStoresPwd\: \(.*\)/keyStoresPwd\: changeit/g" ${A4C_CONFIG}
+      # sudo sed -i -e "s/keyStorePwd\: \(.*\)/keyStorePwd\: changeit/g" ${A4C_CONFIG}
+      # sudo sed -i -e "s/trustStorePwd\: \(.*\)/trustStorePwd\: changeit/g" ${A4C_CONFIG}
   else
       sudo sed -i -e "s/consul_tls_enabled\: \(.*\)/consul_tls_enabled\: false/g" ${A4C_CONFIG}
   fi

--- a/org/alien4cloud/alien4cloud/webapp/scripts/alien/config_alien.sh
+++ b/org/alien4cloud/alien4cloud/webapp/scripts/alien/config_alien.sh
@@ -20,7 +20,7 @@ sudo sed -i "s/username: admin/username: ${ADMIN_USERNAME}/g" ${A4C_CONFIG}
 if [ "$SERVER_PROTOCOL" == "https" ]; then
   echo "Activating ssl endpoint for Alien webapp"
   # enable SSL
-  sudo sed -i -e "s/# ssl\:/ssl\:/g" ${A4C_CONFIG}
+  sudo sed -i -e "s/#  ssl\:/ssl\:/g" ${A4C_CONFIG}
 
   # FIXME: can't be different !!! some confusion somewhere ?
   SERVER_KEYSTORE_PWD="changeit"
@@ -38,9 +38,9 @@ if [ "$SERVER_PROTOCOL" == "https" ]; then
 
   sudo rm -rf $TMP_SSL_DIR
 
-  sudo sed -i -e "s@#   key-store\: \(.*\)@  key-store\: \"$AC4_SSL_DIR/server-keystore.jks\"@g" ${A4C_CONFIG}
-  sudo sed -i -e "s/#   key-store-password\: \(.*\)/  key-store-password\: \"$SERVER_KEYSTORE_PWD\"/g" ${A4C_CONFIG}
-  sudo sed -i -e "s/#   key-password\: \(.*\)/  key-password\: \"$KEY_PWD\"/g" ${A4C_CONFIG}
+  sudo sed -i -e "s@#    key-store\: \(.*\)@  key-store\: \"$AC4_SSL_DIR/server-keystore.jks\"@g" ${A4C_CONFIG}
+  sudo sed -i -e "s/#    key-store-password\: \(.*\)/  key-store-password\: \"$SERVER_KEYSTORE_PWD\"/g" ${A4C_CONFIG}
+  sudo sed -i -e "s/#    key-password\: \(.*\)/  key-password\: \"$KEY_PWD\"/g" ${A4C_CONFIG}
 fi
 
 # get the ES address list

--- a/org/alien4cloud/alien4cloud/webapp/scripts/commons/ssl.sh
+++ b/org/alien4cloud/alien4cloud/webapp/scripts/commons/ssl.sh
@@ -58,20 +58,21 @@ generateKeyAndStore() {
 	echo "[ ssl_client ]" > ${TEMP_DIR}/extfile.cnf
 	echo "extendedKeyUsage=serverAuth,clientAuth" >> ${TEMP_DIR}/extfile.cnf
 	
-	if [ "${PRIVATE_IP}" ]; then
-	   ALT_NAMES = "IP:${PRIVATE_IP}"
+	if [ ! -z "${PRIVATE_IP}" ]; then
+	   ALT_NAMES="IP:${PRIVATE_IP}"
 	fi
-	if [ "${PUBLIC_IP}" ]; then
-	    if [ "${ALT_NAMES}" ]; then
-		     ALT_NAMES = "${ALT_NAMES},IP:${PUBLIC_IP}"
+	if [ ! -z "${PUBLIC_IP}" ]; then
+	    if [ ! -z "${ALT_NAMES}" ]; then
+		     ALT_NAMES="${ALT_NAMES},IP:${PUBLIC_IP}"
 		else
-		    ALT_NAMES = "IP:${PUBLIC_IP}"
+		    ALT_NAMES="IP:${PUBLIC_IP}"
 		fi
 	fi
 
-	if [ "${ALT_NAMES}" ]; then
+	if [ ! -z "${ALT_NAMES}" ]; then
   	    sudo echo "subjectAltName = ${ALT_NAMES}" >> ${TEMP_DIR}/extfile.cnf
 	fi
+
 	openssl x509 -req -days 365 -sha256 \
 	        -in ${TEMP_DIR}/${NAME}.csr -CA ${CA_PEM_FILE} -CAkey ${CA_KEY_FILE} \
 	        -CAcreateserial -out ${TEMP_DIR}/${NAME}-cert.pem \

--- a/org/alien4cloud/alien4cloud/webapp/scripts/commons/ssl.sh
+++ b/org/alien4cloud/alien4cloud/webapp/scripts/commons/ssl.sh
@@ -28,9 +28,20 @@ generateKeyAndStore() {
 	KEYSTORE_PWD=$3
 	IP=$4
 
-    CA_PEM_FILE=${CA_PEM:-$ssl/ca.pem}
-    CA_KEY_FILE=${CA_KEY:-$ssl/ca-key.pem}
+    if [ -z "${CA_PEM}" ]; then
+        CA_PEM_FILE=${TEMP_DIR}/${NAME}-ca.pem
+        echo "${CA_PEM}" > ${CA_PEM_FILE}
+    else
+        CA_PEM_FILE=$ssl/ca.pem
+    fi
 
+   if [ -z "${CA_KEY}" ]; then
+        CA_KEY_FILE=${TEMP_DIR}/${NAME}-ca-key.pem
+        echo "${CA_KEY}" > ${CA_KEY_FILE}
+    else
+        CA_KEY_FILE=$ssl/ca-key.pem
+    fi
+	
 	TEMP_DIR=`mktemp -d`
 
 	# echo "Generate client key"

--- a/org/alien4cloud/alien4cloud/webapp/scripts/commons/ssl.sh
+++ b/org/alien4cloud/alien4cloud/webapp/scripts/commons/ssl.sh
@@ -28,6 +28,9 @@ generateKeyAndStore() {
 	KEYSTORE_PWD=$3
 	IP=$4
 
+    CA_PEM_FILE=${CA_PEM:-$ssl/ca.pem}
+    CA_KEY_FILE=${CA_KEY:-$ssl/ca-key.pem}
+
 	TEMP_DIR=`mktemp -d`
 
 	# echo "Generate client key"
@@ -43,7 +46,7 @@ generateKeyAndStore() {
   	sudo echo "subjectAltName = IP:${IP}" >> ${TEMP_DIR}/extfile.cnf
 	fi
 	openssl x509 -req -days 365 -sha256 \
-	        -in ${TEMP_DIR}/${NAME}.csr -CA $ssl/ca.pem -CAkey $ssl/ca-key.pem \
+	        -in ${TEMP_DIR}/${NAME}.csr -CA ${CA_PEM_FILE} -CAkey ${CA_KEY_FILE} \
 	        -CAcreateserial -out ${TEMP_DIR}/${NAME}-cert.pem \
 	        -passin pass:$CA_PASSPHRASE \
 	        -extfile ${TEMP_DIR}/extfile.cnf -extensions ssl_client
@@ -53,11 +56,11 @@ generateKeyAndStore() {
 	openssl pkcs12 -export -name ${NAME} \
 			-in ${TEMP_DIR}/${NAME}-cert.pem -inkey ${TEMP_DIR}/${NAME}-key.pem \
 			-out ${TEMP_DIR}/${NAME}-keystore.p12 -chain \
-			-CAfile $ssl/ca.pem -caname root \
+			-CAfile ${CA_PEM_FILE} -caname root \
 			-password pass:$KEYSTORE_PWD
 
-	cp $ssl/ca.pem ${TEMP_DIR}/ca.pem
-	openssl x509 -outform der -in $ssl/ca.pem -out ${TEMP_DIR}/ca.csr
+	cp ${CA_PEM_FILE} ${TEMP_DIR}/ca.pem
+	openssl x509 -outform der -in ${CA_PEM_FILE} -out ${TEMP_DIR}/ca.csr
 
 	# return the directory
 	echo ${TEMP_DIR}

--- a/org/alien4cloud/alien4cloud/webapp/scripts/commons/ssl.sh
+++ b/org/alien4cloud/alien4cloud/webapp/scripts/commons/ssl.sh
@@ -28,22 +28,22 @@ generateKeyAndStore() {
 	KEYSTORE_PWD=$3
 	IP=$4
 
+	TEMP_DIR=`mktemp -d`
+
     if [ -z "${CA_PEM}" ]; then
+        CA_PEM_FILE=$ssl/ca.pem
+    else
         CA_PEM_FILE=${TEMP_DIR}/${NAME}-ca.pem
         echo "${CA_PEM}" > ${CA_PEM_FILE}
-    else
-        CA_PEM_FILE=$ssl/ca.pem
     fi
 
    if [ -z "${CA_KEY}" ]; then
+        CA_KEY_FILE=$ssl/ca-key.pem
+    else
         CA_KEY_FILE=${TEMP_DIR}/${NAME}-ca-key.pem
         echo "${CA_KEY}" > ${CA_KEY_FILE}
-    else
-        CA_KEY_FILE=$ssl/ca-key.pem
     fi
 	
-	TEMP_DIR=`mktemp -d`
-
 	# echo "Generate client key"
 	# Generate a key pair
 	openssl genrsa -out ${TEMP_DIR}/${NAME}-key.pem 4096

--- a/org/alien4cloud/alien4cloud/webapp/types.yml
+++ b/org/alien4cloud/alien4cloud/webapp/types.yml
@@ -118,8 +118,8 @@ node_types:
             ALIEN_PUBLIC_ADDRESS: { get_attribute: [HOST, public_address] }
             ALIEN_PORT: { get_property: [SELF, rest, port] }
             DATA_DIR: { get_property: [SELF, data_dir] }
-            TLS_ENABLED: { get_property: [SELF, consul, tls_enabled] }
             # Commented because not used & broken
+            # TLS_ENABLED: { get_property: [SELF, consul, tls_enabled] }
             # KEY_STORE_PATH: { get_property: [SELF, consul, key_store_path] }
             # TRUST_STORE_PATH: { get_property: [SELF, consul, trust_store_path] }
             # KEYSTORE_PWD: { get_property: [SELF, consul, keystore_pwd] }
@@ -172,10 +172,10 @@ relationship_types:
       Configure:
         pre_configure_source:
           inputs:
-            # the capabity name is required here, but in fact I can't guess it
-            # TOSCA limitation ?
-            TLS_ENABLED: { get_property: [SOURCE, consul, tls_enabled] }
-            CA_PASSPHRASE: { get_property: [SOURCE, consul, ca_passphrase] }
+            TLS_ENABLED: { get_property: [TARGET, tls_enabled] }
+            CA_PEM: { get_property: [SOURCE, ca_pem] }
+            CA_KEY: { get_property: [SOURCE, ca_key] }
+            CA_PASSPHRASE: { get_property: [SOURCE, ca_passphrase] }
             AGENT_IP: { get_attribute: [TARGET, ip_address] }
             AGENT_API_PORT: { get_property: [TARGET, consul_agent, port] }
           implementation: scripts/ConnectToConsulAgent/pre_configure_source.sh

--- a/org/alien4cloud/alien4cloud/webapp/types.yml
+++ b/org/alien4cloud/alien4cloud/webapp/types.yml
@@ -115,6 +115,7 @@ node_types:
         configure:
           inputs:
             ALIEN_IP: { get_attribute: [HOST, ip_address] }
+            ALIEN_PUBLIC_ADDRESS: { get_attribute: [HOST, public_address] }
             ALIEN_PORT: { get_property: [SELF, rest, port] }
             DATA_DIR: { get_property: [SELF, data_dir] }
             TLS_ENABLED: { get_property: [SELF, consul, tls_enabled] }

--- a/org/alien4cloud/alien4cloud/webapp/types.yml
+++ b/org/alien4cloud/alien4cloud/webapp/types.yml
@@ -54,8 +54,16 @@ node_types:
       #   default: http
       #   constraints:
       #     - valid_values: ["http", "https"]
+      ca_pem:
+        description: "PEM-encoded certificate authority content, used to check the authenticity of client and server connections"
+        type: string
+        required: false
+      ca_key:
+        description: "Certificate authority private key content"
+        type: string
+        required: false
       ca_passphrase:
-        description: the provided CA cert passphrase
+        description: "Certificate authority private key passphrase"
         type: string
         required: false
     capabilities:
@@ -117,6 +125,8 @@ node_types:
             SERVER_PROTOCOL: { get_property: [SELF, rest, protocol] }
             ADMIN_USERNAME: { get_property: [SELF, rest, user] }
             ADMIN_PASSWORD: { get_property: [SELF, rest, password] }
+            CA_PEM: { get_property: [SELF, ca_pem] }
+            CA_KEY: { get_property: [SELF, ca_key] }
             CA_PASSPHRASE: { get_property: [SELF, ca_passphrase] }
           implementation: scripts/alien/config_alien.sh
         start:


### PR DESCRIPTION
Fixed issues configuring Alien4Cloud in secure mode. Added the ability to provide CA and key in parameter.

The corresponding changes are also embedded into yorc bootstrap pull request https://github.com/ystia/yorc/pull/312 and can be tested following the `how to verify` section of this pull request.
