### PR TITLE
Updated regular expression to match premium/open source config files content

### DIFF
--- a/org/alien4cloud/alien4cloud/webapp/scripts/alien/config_alien.sh
+++ b/org/alien4cloud/alien4cloud/webapp/scripts/alien/config_alien.sh
@@ -19,8 +19,9 @@ sudo sed -i "s/username: admin/username: ${ADMIN_USERNAME}/g" ${A4C_CONFIG}
 
 if [ "$SERVER_PROTOCOL" == "https" ]; then
   echo "Activating ssl endpoint for Alien webapp"
-  # enable SSL
-  sudo sed -i -e "s/#  ssl\:/  ssl\:/g" ${A4C_CONFIG}
+  # enable SSL using a regular expression to match both
+  # premium and open source configuration files content
+  sed -i -e "s/^[[:space:]]*#[[:space:]]\+ssl\:/  ssl\:/g" ${A4C_CONFIG}
 
   # FIXME: can't be different !!! some confusion somewhere ?
   SERVER_KEYSTORE_PWD="changeit"
@@ -38,9 +39,9 @@ if [ "$SERVER_PROTOCOL" == "https" ]; then
 
   sudo rm -rf $TMP_SSL_DIR
 
-  sudo sed -i -e "s@#    key-store\: \(.*\)@    key-store\: \"$AC4_SSL_DIR/server-keystore.jks\"@g" ${A4C_CONFIG}
-  sudo sed -i -e "s/#    key-store-password\: \(.*\)/    key-store-password\: \"$SERVER_KEYSTORE_PWD\"/g" ${A4C_CONFIG}
-  sudo sed -i -e "s/#    key-password\: \(.*\)/    key-password\: \"$KEY_PWD\"/g" ${A4C_CONFIG}
+  sudo sed -i -e "s@^[[:space:]]*#[[:space:]]\+key-store\: \(.*\)@    key-store\: \"$AC4_SSL_DIR/server-keystore.jks\"@g" ${A4C_CONFIG}
+  sudo sed -i -e "s/^[[:space:]]*#[[:space:]]\+key-store-password\: \(.*\)/    key-store-password\: \"$SERVER_KEYSTORE_PWD\"/g" ${A4C_CONFIG}
+  sudo sed -i -e "s/^[[:space:]]*#[[:space:]]\+key-password\: \(.*\)/    key-password\: \"$KEY_PWD\"/g" ${A4C_CONFIG}
 fi
 
 # get the ES address list


### PR DESCRIPTION
Fixes issue https://github.com/alien4cloud/csar-public-library/issues/30 : Alien4cloud component not configured with https on premium version
  
Fixed regular expressions used to configure ssl so that both cases premium and open source configuration are covered.
The premium configuration contains these lines :

```
  # ssl:
  #   key-store: keystore.jks
  #   key-store-password: ******
  #   key-password: ******
```

While the open source version contains :

```
#  ssl:
#    key-store: keystore.jks # Make sure that you have your key store placed along-side the alien4cloud war file.
#    key-store-password: ******
#    key-password: ******
```

Can be tested using yorc bootstrap pull request https://github.com/ystia/yorc/pull/347
