### PR TITLE
Bugfix/gh 22 cleanup vault a4c

### DIFF
--- a/org/alien4cloud/alien4cloud/webapp/bin/alien.sh
+++ b/org/alien4cloud/alien4cloud/webapp/bin/alien.sh
@@ -13,7 +13,7 @@
 
 APP_NAME=alien4cloud
 #PIDFILE=/var/run/${APP_NAME}.pid
-PROC=`ps -ef | grep -e alien4cloud* | grep -v grep | awk -F " " '{ print $2 }'`
+PROC=`ps -ef | grep java | grep $APP_NAME | grep -v grep | awk -F " " '{ print $2 }'`
 
 JAVA_OPTIONS="-server -showversion -XX:+AggressiveOpts -Xmx1400m -Xms1400m -XX:MaxPermSize=512m -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:+HeapDumpOnOutOfMemoryError -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCApplicationStoppedTime -Xloggc:/var/log/alien4cloud/gc.log"
 

--- a/org/alien4cloud/alien4cloud/webapp/scripts/alien/cleanup_alien.sh
+++ b/org/alien4cloud/alien4cloud/webapp/scripts/alien/cleanup_alien.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+source $commons/commons.sh
+
+require_envs "DATA_DIR SERVER_PROTOCOL"
+
+if [ "$SERVER_PROTOCOL" == "https" ]; then
+
+  AC4_SSL_DIR=/etc/alien4cloud/ssl
+  echo "Cleaning up $AC4_SSL_DIR directory"
+
+  sudo /bin/rm -Rf $AC4_SSL_DIR
+
+fi
+
+echo "Cleaning up $DATA_DIR directory"
+sudo /bin/rm -Rf $DATA_DIR
+

--- a/org/alien4cloud/alien4cloud/webapp/scripts/alien/cleanup_alien.sh
+++ b/org/alien4cloud/alien4cloud/webapp/scripts/alien/cleanup_alien.sh
@@ -15,3 +15,6 @@ fi
 echo "Cleaning up $DATA_DIR directory"
 sudo /bin/rm -Rf $DATA_DIR
 
+echo "Cleaning up Alien4Cloud installation directory"
+sudo /bin/rm -Rf /opt/alien4cloud
+

--- a/org/alien4cloud/alien4cloud/webapp/scripts/alien/stop_alien.sh
+++ b/org/alien4cloud/alien4cloud/webapp/scripts/alien/stop_alien.sh
@@ -1,2 +1,2 @@
 #!/bin/bash -e
-sudo /etc/init.d/$service stop
+sudo /etc/init.d/alien stop

--- a/org/alien4cloud/alien4cloud/webapp/types.yml
+++ b/org/alien4cloud/alien4cloud/webapp/types.yml
@@ -138,6 +138,12 @@ node_types:
             ALIEN_PORT: { get_property: [SELF, rest, port] }
             SERVER_PROTOCOL: { get_property: [SELF, rest, protocol] }
           implementation: scripts/alien/start_alien.sh
+        stop: scripts/alien/stop_alien.sh
+        delete:
+          inputs:
+            SERVER_PROTOCOL: { get_property: [SELF, rest, protocol] }
+            DATA_DIR: { get_property: [SELF, data_dir] }
+          implementation: scripts/alien/cleanup_alien.sh
     artifacts:
       - bin:
           file: bin

--- a/org/alien4cloud/vault/vault_sh/scripts/vault/cleanup_vault.sh
+++ b/org/alien4cloud/vault/vault_sh/scripts/vault/cleanup_vault.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+echo "Cleaning up /etc/vault/"
+sudo /bin/rm -Rf /etc/vault/*

--- a/org/alien4cloud/vault/vault_sh/scripts/vault/stop_vault.sh
+++ b/org/alien4cloud/vault/vault_sh/scripts/vault/stop_vault.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+PIDFILE=/var/run/vault.pid
+if [ -f $PIDFILE ]; then
+  PID=`cat $PIDFILE`
+  if [ -z "`ps axf | grep ${PID} | grep -v grep`" ]; then
+    printf "%s\n" "Process dead but pid file exists, removing it"
+  else
+    echo "Stopping vault server"
+    sudo kill -TERM $PID
+  fi
+  sudo /bin/rm $PIDFILE
+fi

--- a/org/alien4cloud/vault/vault_sh/type.yml
+++ b/org/alien4cloud/vault/vault_sh/type.yml
@@ -73,6 +73,8 @@ node_types:
             TLS_DISABLE: { get_property: [SELF, tls_disable] }
             LDAP_ENABLE: { get_property: [SELF, ldap_enable] }
           implementation: scripts/vault/start_vault.sh
+        stop: scripts/vault/stop_vault.sh
+        delete: scripts/vault/cleanup_vault.sh
     artifacts:
       - configs:
           file: configs


### PR DESCRIPTION
Added stop and delete interfaces to Alien4Cloud and VaultServer interfaces,
to be able to re-install on an un-installed setup.

Changes by file:

`org/alien4cloud/alien4cloud/webapp/bin/alien.sh`: 
Updated the ps command to not catch the ansible process launching the stop operation else the ansible execution would fail

`org/alien4cloud/alien4cloud/webapp/scripts/alien/cleanup_alien.sh`:
New script doing a necessary cleanup :
- removing ssl dir or keytool will hang at next re-install attempting to create a keystore
- removing data dir and alien4cloud dir to not keep any runtime data that could cause issues at re-install

`org/alien4cloud/alien4cloud/webapp/scripts/alien/stop_alien.sh`:
Updated script to not rely on non-existing environment variable

`org/alien4cloud/alien4cloud/webapp/types.yml`:
Added stop and delete interfaces

`org/alien4cloud/vault/vault_sh/scripts/vault/cleanup_vault.sh`:
New script to cleanup Vault settings

`org/alien4cloud/vault/vault_sh/scripts/vault/stop_vault.sh`:
New script to stop vault server

`org/alien4cloud/vault/vault_sh/type.yml`:
Added stop and delete interfaces

Fixes #22
