### PR TITLE
Allow to specify extra environment vars

### DIFF
--- a/org/alien4cloud/alien4cloud/webapp/bin/alien.sh
+++ b/org/alien4cloud/alien4cloud/webapp/bin/alien.sh
@@ -21,7 +21,7 @@ case "$1" in
 start)
   printf "%-50s\n" "Starting $APP_NAME ..."
   cd /opt/alien4cloud/alien4cloud/
-  sudo bash -c "/opt/alien4cloud/alien4cloud/alien4cloud.sh ${APP_ARGS} >> /opt/alien4cloud/alien4cloud/logs/vm.out 2>&1 & echo \$!"
+  sudo bash -c "for f in `ls /etc/alien4cloud/env`; do source /etc/alien4cloud/env/\$f; done && /opt/alien4cloud/alien4cloud/alien4cloud.sh ${APP_ARGS} >> /opt/alien4cloud/alien4cloud/logs/vm.out 2>&1 & echo \$!"
 ;;
 status)
   if [[ $PROC ]]; then

--- a/org/alien4cloud/alien4cloud/webapp/scripts/alien/config_alien.sh
+++ b/org/alien4cloud/alien4cloud/webapp/scripts/alien/config_alien.sh
@@ -131,3 +131,7 @@ if [[ "$(which yum)" != "" ]]; then
 elif [[ "$(which apt-get)" != "" ]]; then
   sudo update-rc.d alien defaults 95 10
 fi
+
+if [[ -n "${EXTRA_ENV}" ]] ; then
+  echo "${EXTRA_ENV}" | sudo tee /etc/alien4cloud/env/1_extra_env.sh
+fi

--- a/org/alien4cloud/alien4cloud/webapp/types.yml
+++ b/org/alien4cloud/alien4cloud/webapp/types.yml
@@ -66,6 +66,10 @@ node_types:
         description: "Certificate authority private key passphrase"
         type: string
         required: false
+      extra_env:
+        description: "Extra environment sourced before startup. This will be written as it in a file sourced in the bash process before running Alien"
+        type: string
+        required: false
     capabilities:
       consul:
         type: org.alien4cloud.consul.pub.capabilities.ConsulClient
@@ -129,6 +133,7 @@ node_types:
             CA_PEM: { get_property: [SELF, ca_pem] }
             CA_KEY: { get_property: [SELF, ca_key] }
             CA_PASSPHRASE: { get_property: [SELF, ca_passphrase] }
+            EXTRA_ENV: { get_property: [SELF, extra_env] }
           implementation: scripts/alien/config_alien.sh
         start:
           inputs:


### PR DESCRIPTION
Allow to specify extra environment vars before starting alien
This could be used to specify proxies for instance