### PR TITLE
Relying on Alien4Cloud 2.2.0-SM9 builtin types

### DIFF
--- a/org/alien4cloud/alien4cloud/config/applications/types.yml
+++ b/org/alien4cloud/alien4cloud/config/applications/types.yml
@@ -6,7 +6,7 @@ metadata:
   template_author: alien4cloud
 
 imports:
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
   - org.alien4cloud.alien4cloud.config.csar:2.2.0-SNAPSHOT
   - tosca-normative-types:1.0.0-ALIEN20
 

--- a/org/alien4cloud/alien4cloud/config/csar/types.yml
+++ b/org/alien4cloud/alien4cloud/config/csar/types.yml
@@ -6,7 +6,7 @@ metadata:
   template_author: alien4cloud
 
 imports:
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
   - org.alien4cloud.alien4cloud.pub:2.2.0-SNAPSHOT
   - tosca-normative-types:1.0.0-ALIEN20
 

--- a/org/alien4cloud/alien4cloud/config/location/types.yml
+++ b/org/alien4cloud/alien4cloud/config/location/types.yml
@@ -6,7 +6,7 @@ metadata:
   template_author: alien4cloud
 
 imports:
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
   - org.alien4cloud.alien4cloud.pub:2.2.0-SNAPSHOT
   - org.alien4cloud.alien4cloud.config.pub:2.2.0-SNAPSHOT
   - tosca-normative-types:1.0.0-ALIEN20

--- a/org/alien4cloud/alien4cloud/config/location_resources/autoconfig/types.yml
+++ b/org/alien4cloud/alien4cloud/config/location_resources/autoconfig/types.yml
@@ -6,7 +6,7 @@ metadata:
   template_author: alien4cloud
 
 imports:
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
   - org.alien4cloud.alien4cloud.config.location:2.2.0-SNAPSHOT
   - org.alien4cloud.cloudify.hostpool.pub:2.2.0-SNAPSHOT
   - tosca-normative-types:1.0.0-ALIEN20

--- a/org/alien4cloud/alien4cloud/config/location_resources/cfy_byon/types.yml
+++ b/org/alien4cloud/alien4cloud/config/location_resources/cfy_byon/types.yml
@@ -6,7 +6,7 @@ metadata:
   template_author: alien4cloud
 
 imports:
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
   - org.alien4cloud.alien4cloud.config.location:2.2.0-SNAPSHOT
   - org.alien4cloud.cloudify.hostpool.pub:2.2.0-SNAPSHOT
   - org.alien4cloud.cloudify.manager.pub:2.2.0-SNAPSHOT

--- a/org/alien4cloud/alien4cloud/config/location_resources/on_demand/types.yml
+++ b/org/alien4cloud/alien4cloud/config/location_resources/on_demand/types.yml
@@ -6,7 +6,7 @@ metadata:
   template_author: alien4cloud
 
 imports:
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
   - org.alien4cloud.alien4cloud.config.location:2.2.0-SNAPSHOT
   - org.alien4cloud.cloudify.hostpool.pub:2.2.0-SNAPSHOT
   - tosca-normative-types:1.0.0-ALIEN20

--- a/org/alien4cloud/alien4cloud/config/orchestrator/cfy/types.yml
+++ b/org/alien4cloud/alien4cloud/config/orchestrator/cfy/types.yml
@@ -6,7 +6,7 @@ metadata:
   template_author: alien4cloud
 
 imports:
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
   - org.alien4cloud.alien4cloud.config.pub:2.2.0-SNAPSHOT
   - org.alien4cloud.cloudify.manager.pub:2.2.0-SNAPSHOT
   - tosca-normative-types:1.0.0-ALIEN20

--- a/org/alien4cloud/alien4cloud/config/orchestrator/conf_cfy_azure/types.yml
+++ b/org/alien4cloud/alien4cloud/config/orchestrator/conf_cfy_azure/types.yml
@@ -6,7 +6,7 @@ metadata:
   template_author: alien4cloud
 
 imports:
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
   - org.alien4cloud.alien4cloud.config.pub:2.2.0-SNAPSHOT
   - org.alien4cloud.alien4cloud.config.orchestrator.cfy:2.2.0-SNAPSHOT
   - tosca-normative-types:1.0.0-ALIEN20

--- a/org/alien4cloud/alien4cloud/config/plugin/types.yml
+++ b/org/alien4cloud/alien4cloud/config/plugin/types.yml
@@ -6,7 +6,7 @@ metadata:
   template_author: alien4cloud
 
 imports:
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
   - org.alien4cloud.alien4cloud.pub:2.2.0-SNAPSHOT
   - tosca-normative-types:1.0.0-ALIEN20
 

--- a/org/alien4cloud/alien4cloud/config/pub/types.yml
+++ b/org/alien4cloud/alien4cloud/config/pub/types.yml
@@ -6,7 +6,7 @@ metadata:
   template_author: alien4cloud
 
 imports:
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
   - org.alien4cloud.alien4cloud.pub:2.2.0-SNAPSHOT
   - tosca-normative-types:1.0.0-ALIEN20
 

--- a/org/alien4cloud/alien4cloud/config/repository/types.yml
+++ b/org/alien4cloud/alien4cloud/config/repository/types.yml
@@ -6,7 +6,7 @@ metadata:
   template_author: alien4cloud
 
 imports:
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
   - tosca-normative-types:1.0.0-ALIEN20
   - org.alien4cloud.alien4cloud.pub:2.2.0-SNAPSHOT
 

--- a/org/alien4cloud/alien4cloud/config/service/types.yml
+++ b/org/alien4cloud/alien4cloud/config/service/types.yml
@@ -6,7 +6,7 @@ metadata:
   template_author: alien4cloud
 
 imports:
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
   - tosca-normative-types:1.0.0-ALIEN20
   - org.alien4cloud.alien4cloud.pub:2.2.0-SNAPSHOT
 

--- a/org/alien4cloud/alien4cloud/tests/loadtest/jmeter/types.yml
+++ b/org/alien4cloud/alien4cloud/tests/loadtest/jmeter/types.yml
@@ -7,7 +7,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
   - org.alien4cloud.mock.pub:2.2.0-SNAPSHOT
   - org.alien4cloud.java.pub:2.2.0-SNAPSHOT
   - org.alien4cloud.alien4cloud.pub:2.2.0-SNAPSHOT

--- a/org/alien4cloud/alien4cloud/topologies/a4c_aws_byon/types.yml
+++ b/org/alien4cloud/alien4cloud/topologies/a4c_aws_byon/types.yml
@@ -14,7 +14,7 @@ imports:
   - org.alien4cloud.alien4cloud.config.csar:2.2.0-SNAPSHOT
   - org.alien4cloud.cloudify.manager.pub:2.2.0-SNAPSHOT
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
   - org.alien4cloud.alien4cloud.config.location:2.2.0-SNAPSHOT
   - org.alien4cloud.java.pub:2.2.0-SNAPSHOT
   - org.alien4cloud.java.jmx.jolokia:2.2.0-SNAPSHOT

--- a/org/alien4cloud/alien4cloud/topologies/a4c_mon/types.yml
+++ b/org/alien4cloud/alien4cloud/topologies/a4c_mon/types.yml
@@ -20,7 +20,7 @@ imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - org.alien4cloud.alien4cloud.config.location_resources.on_demand:2.2.0-SNAPSHOT
   - org.alien4cloud.alien4cloud.config.csar:2.2.0-SNAPSHOT
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
   - org.alien4cloud.java.pub:2.2.0-SNAPSHOT
   - org.alien4cloud.diamond.collectors:2.2.0-SNAPSHOT
   - org.alien4cloud.java.jmx.jolokia:2.2.0-SNAPSHOT

--- a/org/alien4cloud/alien4cloud/topologies/load_tests_a4c/types.yml
+++ b/org/alien4cloud/alien4cloud/topologies/load_tests_a4c/types.yml
@@ -31,7 +31,7 @@ imports:
   - org.alien4cloud.alien4cloud.config.orchestrator.cfy:2.2.0-SNAPSHOT
   - org.alien4cloud.diamond.pub:2.2.0-SNAPSHOT
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
   - org.alien4cloud.diamond.collectors:2.2.0-SNAPSHOT
   - org.alien4cloud.java.jmx.jolokia:2.2.0-SNAPSHOT
   - org.alien4cloud.alien4cloud.webapp:2.2.0-SNAPSHOT

--- a/org/alien4cloud/alien4cloud/topologies/load_tests_cfy4/types.yml
+++ b/org/alien4cloud/alien4cloud/topologies/load_tests_cfy4/types.yml
@@ -23,7 +23,7 @@ imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - org.alien4cloud.cloudify.patches.amqp_client:2.2.0-SNAPSHOT
   - org.alien4cloud.cloudify.patches.change_max_mgmtworker:2.2.0-SNAPSHOT
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
   - org.alien4cloud.java.pub:2.2.0-SNAPSHOT
   - org.alien4cloud.diamond.collectors:2.2.0-SNAPSHOT
   - org.alien4cloud.java.jmx.jolokia:2.2.0-SNAPSHOT

--- a/org/alien4cloud/apache/linux_ans/types.yml
+++ b/org/alien4cloud/apache/linux_ans/types.yml
@@ -9,7 +9,7 @@ description: This archive contains an Apache webserver node installed through an
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
   - org.alien4cloud.apache.pub:2.2.0-SNAPSHOT
 
 node_types:

--- a/org/alien4cloud/cloudify/config/a4c_cfy_logs/types.yml
+++ b/org/alien4cloud/cloudify/config/a4c_cfy_logs/types.yml
@@ -6,7 +6,7 @@ metadata:
   template_author: alien4cloud
 
 imports:
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
   - tosca-normative-types:1.0.0-ALIEN20
   - org.alien4cloud.cloudify.manager.pub:2.2.0-SNAPSHOT
 

--- a/org/alien4cloud/cloudify/config/offline_plugin/types.yml
+++ b/org/alien4cloud/cloudify/config/offline_plugin/types.yml
@@ -6,7 +6,7 @@ metadata:
   template_author: alien4cloud
 
 imports:
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
   - tosca-normative-types:1.0.0-ALIEN20
   - org.alien4cloud.apache.pub:2.2.0-SNAPSHOT
   - org.alien4cloud.cloudify.manager.pub:2.2.0-SNAPSHOT

--- a/org/alien4cloud/cloudify/hostpool/awsfeeder/types.yml
+++ b/org/alien4cloud/cloudify/hostpool/awsfeeder/types.yml
@@ -10,7 +10,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
   - org.alien4cloud.cloudify.hostpool.pub:2.2.0-SNAPSHOT
 
 node_types:

--- a/org/alien4cloud/cloudify/hostpool/topologies/hostpool_feeder/types.yml
+++ b/org/alien4cloud/cloudify/hostpool/topologies/hostpool_feeder/types.yml
@@ -15,7 +15,7 @@ imports:
   - org.alien4cloud.cloudify.hostpool.service:2.2.0-SNAPSHOT
   - tosca-normative-types:1.0.0-ALIEN20
   - org.alien4cloud.cloudify.hostpool.pub:2.2.0-SNAPSHOT
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
 
 topology_template:
   description: >

--- a/org/alien4cloud/cloudify/patches/amqp_client/types.yml
+++ b/org/alien4cloud/cloudify/patches/amqp_client/types.yml
@@ -9,7 +9,7 @@ description: Fix AMQP client patch.
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
   - org.alien4cloud.cloudify.manager.pub:2.2.0-SNAPSHOT
   - org.alien4cloud.cloudify.patches.pub:2.2.0-SNAPSHOT
 

--- a/org/alien4cloud/cloudify/patches/change_max_fd/types.yml
+++ b/org/alien4cloud/cloudify/patches/change_max_fd/types.yml
@@ -9,7 +9,7 @@ description: Fix AMQP client patch.
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
   - org.alien4cloud.cloudify.manager.pub:2.2.0-SNAPSHOT
   - org.alien4cloud.cloudify.patches.pub:2.2.0-SNAPSHOT
 

--- a/org/alien4cloud/cloudify/patches/change_max_mgmtworker/types.yml
+++ b/org/alien4cloud/cloudify/patches/change_max_mgmtworker/types.yml
@@ -9,7 +9,7 @@ description: Fix AMQP client patch.
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
   - org.alien4cloud.cloudify.manager.pub:2.2.0-SNAPSHOT
   - org.alien4cloud.cloudify.patches.pub:2.2.0-SNAPSHOT
 

--- a/org/alien4cloud/cloudify/patches/patch_tasks/types.yml
+++ b/org/alien4cloud/cloudify/patches/patch_tasks/types.yml
@@ -9,7 +9,7 @@ description: Patch tasks.py
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
   - org.alien4cloud.cloudify.manager.pub:2.2.0-SNAPSHOT
   - org.alien4cloud.cloudify.patches.pub:2.2.0-SNAPSHOT
 

--- a/org/alien4cloud/cloudify/topologies/cfy411_aws/types.yml
+++ b/org/alien4cloud/cloudify/topologies/cfy411_aws/types.yml
@@ -24,7 +24,7 @@ imports:
   - org.alien4cloud.cloudify.hostpool.pub:2.2.0-SNAPSHOT
   - org.alien4cloud.postgresql.pub:2.2.0-SNAPSHOT
   - org.alien4cloud.rabbitmq.pub:2.2.0-SNAPSHOT
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
 
 topology_template:
   inputs:

--- a/org/alien4cloud/cloudify/topologies/cfy4_hp_aws/types.yml
+++ b/org/alien4cloud/cloudify/topologies/cfy4_hp_aws/types.yml
@@ -21,7 +21,7 @@ imports:
   - org.alien4cloud.cloudify.manager.pub:2.2.0-SNAPSHOT
   - org.alien4cloud.diamond.pub:2.2.0-SNAPSHOT
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
   - org.alien4cloud.java.pub:2.2.0-SNAPSHOT
   - org.alien4cloud.diamond.collectors:2.2.0-SNAPSHOT
   - org.alien4cloud.java.jmx.jolokia:2.2.0-SNAPSHOT

--- a/org/alien4cloud/cloudify/topologies/hostpool_as_a_service/types.yml
+++ b/org/alien4cloud/cloudify/topologies/hostpool_as_a_service/types.yml
@@ -15,7 +15,7 @@ imports:
   - org.alien4cloud.cloudify.manager.pub:2.2.0-SNAPSHOT
   - tosca-normative-types:1.0.0-ALIEN20
   - org.alien4cloud.cloudify.hostpool.pub:2.2.0-SNAPSHOT
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
 
 topology_template:
   inputs:

--- a/org/alien4cloud/diamond/agent_linux/types.yml
+++ b/org/alien4cloud/diamond/agent_linux/types.yml
@@ -7,7 +7,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
   - org.alien4cloud.graphite.pub:2.2.0-SNAPSHOT
   - org.alien4cloud.grafana.pub:2.2.0-SNAPSHOT
   - org.alien4cloud.diamond.pub:2.2.0-SNAPSHOT

--- a/org/alien4cloud/diamond/collectors/types.yml
+++ b/org/alien4cloud/diamond/collectors/types.yml
@@ -7,7 +7,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
   - org.alien4cloud.monitoring.pub:2.2.0-SNAPSHOT
   - org.alien4cloud.elasticsearch.pub:2.2.0-SNAPSHOT
   - org.alien4cloud.diamond.pub:2.2.0-SNAPSHOT

--- a/org/alien4cloud/grafana/linux_ans/types.yml
+++ b/org/alien4cloud/grafana/linux_ans/types.yml
@@ -7,7 +7,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
   - org.alien4cloud.grafana.pub:2.2.0-SNAPSHOT
   - org.alien4cloud.graphite.pub:2.2.0-SNAPSHOT
 

--- a/org/alien4cloud/graphite/linux_ans/types.yml
+++ b/org/alien4cloud/graphite/linux_ans/types.yml
@@ -8,7 +8,7 @@ metadata:
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - org.alien4cloud.graphite.pub:2.2.0-SNAPSHOT
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
 
 node_types:
 

--- a/org/alien4cloud/mock/ansible/types.yml
+++ b/org/alien4cloud/mock/ansible/types.yml
@@ -7,7 +7,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
   - org.alien4cloud.mock.pub:2.2.0-SNAPSHOT
 
 description: >

--- a/org/alien4cloud/mock/topologies/simple_ansible/types.yml
+++ b/org/alien4cloud/mock/topologies/simple_ansible/types.yml
@@ -12,7 +12,7 @@ imports:
   - org.alien4cloud.mock.pub:2.2.0-SNAPSHOT
   - org.alien4cloud.mock.ansible:2.2.0-SNAPSHOT
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
 
 topology_template:
   inputs:

--- a/org/alien4cloud/monitoring/topologies/grafana_graphite/types.yml
+++ b/org/alien4cloud/monitoring/topologies/grafana_graphite/types.yml
@@ -17,7 +17,7 @@ imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - org.alien4cloud.grafana.linux_ans:2.2.0-SNAPSHOT
   - org.alien4cloud.diamond.agent_linux:2.2.0-SNAPSHOT
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
   - org.alien4cloud.java.pub:2.2.0-SNAPSHOT
   - org.alien4cloud.java.jmx.jolokia:2.2.0-SNAPSHOT
   - org.alien4cloud.diamond.pub:2.2.0-SNAPSHOT

--- a/org/alien4cloud/monitoring/topologies/monitored_centos/types.yml
+++ b/org/alien4cloud/monitoring/topologies/monitored_centos/types.yml
@@ -14,7 +14,7 @@ imports:
   - org.alien4cloud.cloudify.manager.pub:2.2.0-SNAPSHOT
   - tosca-normative-types:1.0.0-ALIEN20
   - org.alien4cloud.diamond.agent_linux:2.2.0-SNAPSHOT
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
   - org.alien4cloud.java.pub:2.2.0-SNAPSHOT
   - org.alien4cloud.diamond.pub:2.2.0-SNAPSHOT
   - org.alien4cloud.java.jmx.jolokia:2.2.0-SNAPSHOT

--- a/org/alien4cloud/mysql/linux_pup/types.yml
+++ b/org/alien4cloud/mysql/linux_pup/types.yml
@@ -9,7 +9,7 @@ description: MySQL RDBMS installation  with Puppet, tested with ami-ed82e39e (t2
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
   - org.alien4cloud.agentpuppet:2.2.0-SNAPSHOT
   - org.alien4cloud.mysql.pub:2.2.0-SNAPSHOT
 

--- a/org/alien4cloud/spark/job-linux-sh/types.yml
+++ b/org/alien4cloud/spark/job-linux-sh/types.yml
@@ -11,7 +11,7 @@ description: |
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - org.alien4cloud.spark.pub:2.2.0-SNAPSHOT
-  - alien-base-types:2.2.0-SM6
+  - alien-base-types:2.2.0-SM9
 
 data_types:
   org.alien4cloud.spark.jobs-linux-sh.datatypes.SubmissionProperties:


### PR DESCRIPTION
Updated dependency on Alien4Cloud components, from 2.2.0-SM6 to 2.2.0-SM9